### PR TITLE
fix image query for GPU flavors

### DIFF
--- a/component/client.js
+++ b/component/client.js
@@ -29,7 +29,6 @@ function viaProxy(url) {
 const validImageProperties = {
   visibility:    'public',
   protected:     true,
-  __support_kvm: true,
   __os_type:     'Linux',
   __os_bit:      64,
 }

--- a/component/component.js
+++ b/component/component.js
@@ -438,6 +438,7 @@ export default Ember.Component.extend(NodeDriver, {
       return []
     }
     return this.otc.listNodeImages().then(images => {
+      console.log('Images: ', images)
       return images.map(i => {
         return {
           label: i.name,


### PR DESCRIPTION
GPU image now querying without any errors, cause was in __support_kvm query parameter, because GPU image have different one.

Closes #42 