### PR TITLE
Deperecation message

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -5,9 +5,11 @@
       jobs:
         - js-build-ubuntu:
             vars:
+              node_version: 20
               js_build_command: "build -- --ui-version SNAPSHOT"
     gate:
       jobs:
         - js-build-ubuntu:
             vars:
+              node_version: 20
               js_build_command: "build -- --ui-version SNAPSHOT"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# ui-driver-skel
-Skeleton Rancher UI driver for custom docker-machine drivers
+# ui-driver-otc
+Rancher UI driver for custom docker-machine drivers (Node)
 
-**Note: The Master branch works with Rancher 2.x+, if you are building a custom driver for Rancher 1.x use the 1.x branch**
+**Note: The Master branch works with Rancher 2.x+ (till 2.11), if you are building a custom driver for Rancher 1.x use the 1.x branch**
+
+**Note**: Support for UI Plugins (based on Ember) for cluster and node drivers was deprecated in Rancher 2.11.0 and will be removed in a future release.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ui-driver-otc
 Rancher UI driver for custom docker-machine drivers (Node)
 
-**Note: The Master branch works with Rancher 2.x+ (till 2.11), if you are building a custom driver for Rancher 1.x use the 1.x branch**
+**Note**: The Master branch works with Rancher 2.x+ (till 2.11), if you are building a custom driver for Rancher 1.x use the 1.x branch**
 
 **Note**: Support for UI Plugins (based on Ember) for cluster and node drivers was deprecated in Rancher 2.11.0 and will be removed in a future release.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ui-driver-otc
 Rancher UI driver for custom docker-machine drivers (Node)
 
-**Note**: The Master branch works with Rancher 2.x+ (till 2.11), if you are building a custom driver for Rancher 1.x use the 1.x branch**
+**Note**: The Master branch works with Rancher 2.x+ (till 2.11), if you are building a custom driver for Rancher 1.x use the 1.x branch
 
 **Note**: Support for UI Plugins (based on Ember) for cluster and node drivers was deprecated in Rancher 2.11.0 and will be removed in a future release.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ui-driver-otc",
-  "version": "0.1.0",
+  "name": "@opentelekomcloud/ui-driver-otc",
+  "version": "1.0.3",
   "description": "OpenTelekomCloud Node Driver",
   "repository": {
     "type": "git",
@@ -11,6 +11,16 @@
   "bugs": {
     "url": "https://github.com/opentelekomcloud/ui-driver-otc/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist/",
+    "component/",
+    "assets/",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "start": "./node_modules/.bin/gulp server",
     "clean": "./node_modules/.bin/gulp clean",


### PR DESCRIPTION
Support for UI Plugins (based on Ember) for cluster and node drivers was deprecated in Rancher 2.11.0 and will be removed in a future release.